### PR TITLE
Sort and categorize config_default.yaml

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -1,10 +1,34 @@
+# --------------- Main ---------------
+
 library: library.db
 directory: ~/Music
+statefile: state.pickle
+
+# --------------- Plugins ---------------
+
+plugins: []
+pluginpath: []
+
+# --------------- Import ---------------
+
+clutter: ["Thumbs.DB", ".DS_Store"]
+ignore: [".*", "*~", "System Volume Information", "lost+found"]
+ignore_hidden: yes
 
 import:
+    # common options
     write: yes
     copy: yes
     move: no
+    timid: no
+    quiet: no
+    log:
+    # other options
+    default_action: apply
+    languages: []
+    quiet_fallback: skip
+    none_rec_action: ask
+    # rare options
     link: no
     hardlink: no
     reflink: no
@@ -13,15 +37,8 @@ import:
     incremental: no
     incremental_skip_later: no
     from_scratch: no
-    quiet_fallback: skip
-    none_rec_action: ask
-    timid: no
-    log:
     autotag: yes
-    quiet: no
     singletons: no
-    default_action: apply
-    languages: []
     detail: no
     flat: no
     group_albums: no
@@ -37,10 +54,13 @@ import:
     ignored_alias_types: []
     singleton_album_disambig: yes
 
-clutter: ["Thumbs.DB", ".DS_Store"]
-ignore: [".*", "*~", "System Volume Information", "lost+found"]
-ignore_hidden: yes
+# --------------- Paths ---------------
 
+path_sep_replace: _
+drive_sep_replace: _
+asciify_paths: false
+art_filename: cover
+max_filename_length: 0
 replace:
     # Replace bad characters with _
     # prohibited in many filesystem paths
@@ -60,11 +80,6 @@ replace:
     # starting and closing whitespace
     '\s+$': ''
     '^\s+': ''
-path_sep_replace: _
-drive_sep_replace: _
-asciify_paths: false
-art_filename: cover
-max_filename_length: 0
 
 aunique:
     keys: albumartist album
@@ -76,21 +91,27 @@ sunique:
     disambiguators: year trackdisambig
     bracket: '[]'
 
-overwrite_null:
-  album: []
-  track: []
+# --------------- Tagging ---------------
 
-plugins: []
-pluginpath: []
-threaded: yes
-timeout: 5.0
 per_disc_numbering: no
-verbose: 0
-terminal_encoding:
 original_date: no
 artist_credit: no
 id3v23: no
 va_name: "Various Artists"
+paths:
+    default: $albumartist/$album%aunique{}/$track $title
+    singleton: Non-Album/$artist/$title
+    comp: Compilations/$album%aunique{}/$track $title
+
+# --------------- Performance ---------------
+
+threaded: yes
+timeout: 5.0
+
+# --------------- UI ---------------
+
+verbose: 0
+terminal_encoding:
 
 ui:
     terminal_width: 80
@@ -126,6 +147,8 @@ ui:
             match_tracklist: 5
         layout: column
 
+# --------------- Search ---------------
+
 format_item: $artist - $album - $title
 format_album: $albumartist - $album
 time_format: '%Y-%m-%d %H:%M:%S'
@@ -135,13 +158,14 @@ sort_album: albumartist+ album+
 sort_item: artist+ album+ disc+ track+
 sort_case_insensitive: yes
 
-paths:
-    default: $albumartist/$album%aunique{}/$track $title
-    singleton: Non-Album/$artist/$title
-    comp: Compilations/$album%aunique{}/$track $title
+# --------------- Autotagger ---------------
 
-statefile: state.pickle
+# FIXME undocumented feature
+# https://github.com/beetbox/beets/blob/c15ccb16bf3bceadfdf50268818dd64f04de25f8/beets/autotag/__init__.py#L219
 
+overwrite_null:
+  album: []
+  track: []
 musicbrainz:
     enabled: yes
     host: musicbrainz.org


### PR DESCRIPTION
## Description

Sorted the default config into categories, more or less. Added a FIXME and URL for an undocumented feature but otherwise it just re-arranges the existing config. No changes to substance.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] ~Tests. (Very much encouraged but not strictly required.)~
